### PR TITLE
Added "options" button and disabled "copy message" button when necessary

### DIFF
--- a/play/binary-explorer/index.html
+++ b/play/binary-explorer/index.html
@@ -60,13 +60,26 @@
 			<hr>
 
 			<p style="text-align: right">
-				<button class="btn btn-primary" onclick="addRow()">Add Letter</button>
-				<button class="btn btn-success" onclick="addToMessage()">Add Letters to Message</button>
-				<button class="btn btn-warning" onclick="deleteMessage()">Delete Message</button>
+				<button class="btn btn-primary" onclick="addRow()">
+					<i class="fas fa-plus"></i>
+					Add Letter
+				</button>
+
+				<button class="btn btn-success" onclick="addToMessage()">
+					<i class="fas fa-pen"></i>
+					Write Letters to Message
+				</button>
+
+				<button class="btn btn-warning" onclick="deleteMessage()">
+					<i class="fas fa-trash-alt"></i>
+					Delete Message
+				</button>
+
 				<button class="btn btn-secondary" id="copy-button" onclick="copyMessage()" disabled>
 					<i class="fas fa-copy"></i>
 					Copy Message
 				</button>
+
 				<button type="button" class="btn btn-outline-dark" data-toggle="modal" data-target="#options">
 					<i class="fas fa-cog"></i>
 					Options
@@ -140,7 +153,7 @@
 							<input type="radio" id="character" name="copy" value="character" checked>
 							<label for="character">Copy Message using Characters</label><br>
 							<input type="radio" id="binary" name="copy" value="binary">
-							<label for="binary">Copy Message using Binary</label><br>
+							<label for="binary">Copy Binary Message (eg. "1001000 1101001")</label><br>
 						</form>
 					</div>
 

--- a/play/binary-explorer/index.html
+++ b/play/binary-explorer/index.html
@@ -63,9 +63,13 @@
 				<button class="btn btn-primary" onclick="addRow()">Add Letter</button>
 				<button class="btn btn-success" onclick="addToMessage()">Add Letters to Message</button>
 				<button class="btn btn-warning" onclick="deleteMessage()">Delete Message</button>
-				<button class="btn btn-secondary" onclick="copyMessage()">
+				<button class="btn btn-secondary" id="copy-button" onclick="copyMessage()" disabled>
 					<i class="fas fa-copy"></i>
 					Copy Message
+				</button>
+				<button type="button" class="btn btn-outline-dark" data-toggle="modal" data-target="#options">
+					<i class="fas fa-cog"></i>
+					Options
 				</button>
 			</p>
 
@@ -116,6 +120,32 @@
 						<div class="modal-footer">
 							<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
 						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<!-- Options Modal -->
+		<div class="modal fade" id="options" role="dialog">
+			<div class="modal-dialog">
+				<div class="modal-content">
+					<div class="modal-header">
+						<h4 class="modal-title">Options</h4>
+						<button type="button" class="close" data-dismiss="modal">&times;</button>
+					</div>
+
+					<div class="modal-body">
+						<p>Select the way you would like to copy your message.</p>
+						<form>
+							<input type="radio" id="character" name="copy" value="character" checked>
+							<label for="character">Copy Message using Characters</label><br>
+							<input type="radio" id="binary" name="copy" value="binary">
+							<label for="binary">Copy Message using Binary</label><br>
+						</form>
+					</div>
+
+					<div class="modal-footer">
+						<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
 					</div>
 				</div>
 			</div>

--- a/play/binary-explorer/js/app.js
+++ b/play/binary-explorer/js/app.js
@@ -97,6 +97,9 @@ function addToMessage() {
         deleteRow(div.querySelector(".letter"));
     }
     addRow();
+
+    // enable "Copy Message" button
+    if (span.innerHTML) document.getElementById("copy-button").disabled = false;
 }
 
 /**
@@ -105,14 +108,32 @@ function addToMessage() {
 function deleteMessage() {
     let span = document.getElementById("message");
     document.getElementById("message-container").removeChild(span);
+
+    // disable "Copy Message" button
+    document.getElementById("copy-button").disabled = true;
 }
 
 /**
  * Copies message to clipboard.
  */
 function copyMessage() {
-    let copyText = document.getElementById("message").innerHTML;
-    navigator.clipboard.writeText(copyText)
-        .then(() => alert("Copied the text: " + copyText))
-        .catch(err => alert("Error in copying text"));
+    // copy message using characters
+    if (document.getElementById("character").checked) {
+        let copyText = document.getElementById("message").innerHTML;
+        navigator.clipboard.writeText(copyText)
+            .then(() => alert(`Copied the message \"${copyText}\".`))
+            .catch(err => alert("Error in copying text"));
+    }
+
+    // copy message using binary
+    if (document.getElementById("binary").checked) {
+        let copyText = document.getElementById("message").innerHTML;
+        let binaryText = "";
+        for (let i = 0; i < copyText.length; i++) {
+            binaryText += copyText[i].charCodeAt(0).toString(2) + " ";
+        }
+        navigator.clipboard.writeText(binaryText)
+            .then(() => alert(`Copied the string \"${binaryText}\", which translates to \"${copyText}\".`))
+            .catch(err => alert("Error in copying text"));
+    }
 }


### PR DESCRIPTION
The "options" button contains the ability to toggle between copying the message using characters or using binary strings. After experimenting, I think this implementation is preferable as it gives the user the ability to copy using both methods while minimizing visual clutter.